### PR TITLE
Use layer ID map for sorted draw lists

### DIFF
--- a/im3d.cpp
+++ b/im3d.cpp
@@ -2026,13 +2026,13 @@ void Context::sort()
 		 // if draw list is empty or the layer or primitive changed, start a new draw list
 			if (false
 				|| first
-				|| (m_drawLists.back().m_layerId  != layer)
+				|| (m_drawLists.back().m_layerId  != m_layerIdMap[layer])
 				|| (m_drawLists.back().m_primType != mxprim)
 				) 
 			{
 				cprim = mxprim;
 				DrawList dl;
-				dl.m_layerId     = layer;
+				dl.m_layerId     = m_layerIdMap[layer];
 				dl.m_primType    = (DrawPrimitiveType)cprim;
 				dl.m_vertexData  = m_vertexData[1][layer * DrawPrimitive_Count + cprim]->data() + (search[cprim] - sortData[cprim].data()) * VertsPerDrawPrimitive[cprim];
 				dl.m_vertexCount = 0;


### PR DESCRIPTION
The layer IDs were not set correctly when constructing draw lists from sorted primitives, so using gizmos in different layers did not work:
```
// in the main loop
Im3d::PushLayerId("gizmoLayer");
Im3d::Gizmo("mygizmo", &transform);
Im3d::PopLayerId();

// in the rendering code
if (drawList.m_layerId == Im3d::MakeId("gizmoLayer")) {
    // will never reach here
}
```
This patch simply sets the layer ID of the draw list from the current index in the ID map.