### PR TITLE
Fix ce with clang-cl.

### DIFF
--- a/im3d.cpp
+++ b/im3d.cpp
@@ -1398,18 +1398,13 @@ void Vector<T>::swap(Vector<T>& _a_, Vector<T>& _b_)
 	_b_.m_size     = size;
 }
 
-namespace Im3d
-{
-
-template struct Vector<bool>;
-template struct Vector<char>;
-template struct Vector<float>;
-template struct Vector<Id>;
-template struct Vector<Mat4>;
-template struct Vector<Color>;
-template struct Vector<DrawList>;
-
-}
+template struct Im3d::Vector<bool>;
+template struct Im3d::Vector<char>;
+template struct Im3d::Vector<float>;
+template struct Im3d::Vector<Id>;
+template struct Im3d::Vector<Mat4>;
+template struct Im3d::Vector<Color>;
+template struct Im3d::Vector<DrawList>;
 
 /*******************************************************************************
 

--- a/im3d.cpp
+++ b/im3d.cpp
@@ -1398,6 +1398,9 @@ void Vector<T>::swap(Vector<T>& _a_, Vector<T>& _b_)
 	_b_.m_size     = size;
 }
 
+namespace Im3d
+{
+
 template struct Vector<bool>;
 template struct Vector<char>;
 template struct Vector<float>;
@@ -1405,6 +1408,8 @@ template struct Vector<Id>;
 template struct Vector<Mat4>;
 template struct Vector<Color>;
 template struct Vector<DrawList>;
+
+}
 
 /*******************************************************************************
 


### PR DESCRIPTION
When compiled with clang-cl (LLVM toolset integrated in Visual Studio), it complains:

```
error : explicit instantiation of 'Im3d::Vector' must occur in namespace 'Im3d'
```

Explicit instantiation can only appear in the enclosing namespace of the template, unless it uses qualified-id (see 'Explicit instantiation' section in [cppreference](https://en.cppreference.com/w/cpp/language/class_template)). So it can be fixed by adding a `Im3d` namespace to warp the explicit instantiation codes.