### PR TITLE
Fix warnings and remove trailing whitespaces.

### DIFF
--- a/im3d.cpp
+++ b/im3d.cpp
@@ -812,7 +812,7 @@ bool Im3d::GizmoTranslation(Id _id, float _translation_[3], bool _local)
 				ret |= ctx.gizmoPlaneTranslation_Behavior(plane.m_id, ctx.getMatrix() * plane.m_origin, axes[i].m_axis, appData.m_snapTranslation, planeSize, outVec3);
 			}
 		}
-	} 
+	}
 	else
 	{
 		ctx.pushMatrix(Mat4(1.0f));
@@ -1617,7 +1617,7 @@ void Context::text(const Vec3& _position, float _size, Color _color, TextFlags _
 	td.m_flags = _flags;
 	td.m_textBufferOffset = m_textBuffer.size();
 	td.m_textLength = (U32)(_textEnd - _textStart);
-	
+
 	const U32 copyOffset = m_textBuffer.size();
 	m_textBuffer.resize(copyOffset + td.m_textLength + 1);
 	memcpy(m_textBuffer.data() + copyOffset, _textStart, (size_t)td.m_textLength);
@@ -1637,7 +1637,6 @@ void Context::text(const Vec3& _position, float _size, Color _color, TextFlags _
 	td.m_color.setA(td.m_color.getA() * m_alphaStack.back());
 	td.m_flags = _flags;
 	td.m_textBufferOffset = m_textBuffer.size();
-	
 
 	va_list argsCopy;
 	va_copy(argsCopy, _args);
@@ -1677,7 +1676,7 @@ void Context::reset()
 	}
 	m_textDrawLists.clear();
 	m_textBuffer.clear();
-	
+
 	m_sortCalled = false;
 	m_endFrameCalled = false;
 
@@ -1733,7 +1732,7 @@ void Context::merge(const Context& _src)
  // layer IDs
 	for (Id id : _src.m_layerIdMap)
 	{
-		pushLayerId(id); // add a new layer if id doesn't alrady exist 
+		pushLayerId(id); // add a new layer if id doesn't alrady exist
 		popLayerId();
 	}
 
@@ -2043,7 +2042,7 @@ void Context::sort()
 				|| first
 				|| (m_drawLists.back().m_layerId  != m_layerIdMap[layer])
 				|| (m_drawLists.back().m_primType != mxprim)
-				) 
+				)
 			{
 				cprim = mxprim;
 				DrawList dl;

--- a/im3d.h
+++ b/im3d.h
@@ -364,14 +364,14 @@ struct IM3D_API Color
 	          Color(const Vec4& _rgba);
 	          Color(const Vec3& _rgb, float _alpha);
 	          Color(float _r, float _g, float _b, float _a = 1.0f);
-	
+
 	operator U32() const                                                     { return v; }
 
 	void set(int _i, float _val)
 	{
 		_i *= 8;
 		U32 mask = 0xff << _i;
-		v = (v & ~mask) | ((U32)(_val * 255.0f) << _i);
+		v = (v & ~mask) | (U32(_val * 255.0f) << _i);
 	}
 	void setR(float _val)                                                    { set(3, _val); }
 	void setG(float _val)                                                    { set(2, _val); }
@@ -382,7 +382,7 @@ struct IM3D_API Color
 	{
 		_i *= 8;
 		U32 mask = 0xff << _i;
-		return (float)((v & mask) >> _i) / 255.0f;
+		return float((v & mask) >> _i) / 255.0f;
 	}
 	float getR() const                                                       { return get(3); }
 	float getG() const                                                       { return get(2); }

--- a/im3d_config.h
+++ b/im3d_config.h
@@ -5,7 +5,7 @@
 
 // User-defined malloc/free. Define both or neither (default is cstdlib malloc()/free()).
 //#define IM3D_MALLOC(size) malloc(size)
-//#define IM3D_FREE(ptr) free(ptr) 
+//#define IM3D_FREE(ptr) free(ptr)
 
 // User-defined API declaration (e.g. __declspec(dllexport)).
 //#define IM3D_API
@@ -13,7 +13,7 @@
 // Use a thread-local context pointer.
 //#define IM3D_THREAD_LOCAL_CONTEXT_PTR 1
 
-// Use row-major internal matrix layout. 
+// Use row-major internal matrix layout.
 //#define IM3D_MATRIX_ROW_MAJOR 1
 
 // Force vertex data alignment (default is 4 bytes).
@@ -26,18 +26,18 @@
 //#define IM3D_CULL_GIZMOS 1
 
 // Conversion to/from application math types.
-//#define IM3D_VEC2_APP \
-//	Vec2(const glm::vec2& _v)          { x = _v.x; y = _v.y;     } \
+//#define IM3D_VEC2_APP
+//	Vec2(const glm::vec2& _v)          { x = _v.x; y = _v.y;     }
 //	operator glm::vec2() const         { return glm::vec2(x, y); }
-//#define IM3D_VEC3_APP \
-//	Vec3(const glm::vec3& _v)          { x = _v.x; y = _v.y; z = _v.z; } \
+//#define IM3D_VEC3_APP
+//	Vec3(const glm::vec3& _v)          { x = _v.x; y = _v.y; z = _v.z; }
 //	operator glm::vec3() const         { return glm::vec3(x, y, z);    }
-//#define IM3D_VEC4_APP \
-//	Vec4(const glm::vec4& _v)          { x = _v.x; y = _v.y; z = _v.z; w = _v.w; } \
+//#define IM3D_VEC4_APP
+//	Vec4(const glm::vec4& _v)          { x = _v.x; y = _v.y; z = _v.z; w = _v.w; }
 //	operator glm::vec4() const         { return glm::vec4(x, y, z, w);           }
-//#define IM3D_MAT3_APP \
-//	Mat3(const glm::mat3& _m)          { for (int i = 0; i < 9; ++i) m[i] = *(&(_m[0][0]) + i); } \
+//#define IM3D_MAT3_APP
+//	Mat3(const glm::mat3& _m)          { for (int i = 0; i < 9; ++i) m[i] = *(&(_m[0][0]) + i); }
 //	operator glm::mat3() const         { glm::mat3 ret; for (int i = 0; i < 9; ++i) *(&(ret[0][0]) + i) = m[i]; return ret; }
-//#define IM3D_MAT4_APP \
-//	Mat4(const glm::mat4& _m)          { for (int i = 0; i < 16; ++i) m[i] = *(&(_m[0][0]) + i); } \
+//#define IM3D_MAT4_APP
+//	Mat4(const glm::mat4& _m)          { for (int i = 0; i < 16; ++i) m[i] = *(&(_m[0][0]) + i); }
 //	operator glm::mat4() const         { glm::mat4 ret; for (int i = 0; i < 16; ++i) *(&(ret[0][0]) + i) = m[i]; return ret; }

--- a/im3d_math.h
+++ b/im3d_math.h
@@ -29,13 +29,13 @@ inline Vec3  operator*(const Vec3& _lhs, const Vec3& _rhs) { return Vec3(_lhs.x 
 inline Vec3  operator/(const Vec3& _lhs, const Vec3& _rhs) { return Vec3(_lhs.x / _rhs.x, _lhs.y / _rhs.y, _lhs.z / _rhs.z); }
 inline Vec3  operator*(const Vec3& _lhs, float _rhs)       { return Vec3(_lhs.x * _rhs, _lhs.y * _rhs, _lhs.z * _rhs);       }
 inline Vec3  operator/(const Vec3& _lhs, float _rhs)       { return Vec3(_lhs.x / _rhs, _lhs.y / _rhs, _lhs.z / _rhs);       }
-inline Vec3  operator-(const Vec3& _v)                     { return Vec3(-_v.x, -_v.y, -_v.z);                               } 
+inline Vec3  operator-(const Vec3& _v)                     { return Vec3(-_v.x, -_v.y, -_v.z);                               }
 inline float Dot(const Vec3& _lhs, const Vec3& _rhs)       { return _lhs.x * _rhs.x + _lhs.y * _rhs.y + _lhs.z * _rhs.z;     }
 inline float Length(const Vec3& _v)                        { return sqrtf(Dot(_v, _v));                                      }
 inline float Length2(const Vec3& _v)                       { return Dot(_v, _v);                                             }
 inline Vec3  Abs(const Vec3& _v)                           { return Vec3(fabs(_v.x), fabs(_v.y), fabs(_v.z));                }
 inline Vec3  Normalize(const Vec3& _v)                     { return _v / Length(_v);                                         }
-inline Vec3  Cross(const Vec3& _a, const Vec3& _b)         
+inline Vec3  Cross(const Vec3& _a, const Vec3& _b)
 {
 	return Vec3(
 		_a.y * _b.z - _b.y * _a.z,
@@ -165,7 +165,7 @@ struct LineSegment
 	Vec3 m_end;
 
 	LineSegment() {}
-	LineSegment(const Vec3& _start, const Vec3& _end);	
+	LineSegment(const Vec3& _start, const Vec3& _end);
 };
 struct Sphere
 {
@@ -173,7 +173,7 @@ struct Sphere
 	float m_radius;
 
 	Sphere() {}
-	Sphere(const Vec3& _origin, float _radius);	
+	Sphere(const Vec3& _origin, float _radius);
 };
 struct Plane
 {
@@ -189,7 +189,7 @@ struct Capsule
 	Vec3  m_start;
 	Vec3  m_end;
 	float m_radius;
-	
+
 	Capsule() {}
 	Capsule(const Vec3& _start, const Vec3& _end, float _radius);
 };


### PR DESCRIPTION
Hello and Marry Christmas!

I got some warnings compiling im3d with gcc, so this PR fixes them. I also used editorconfig to remove some trailing whitespaces.
The warnings were about the backslash used in the comments in `im3d_config.h` (that I removed because they weren't used for multiline comments) and for the use of old-style cast of some values in `im3d.h` (replaced by functional casting).