### PR TITLE
translation gizmo: apply correct snapping to rotated axes

### DIFF
--- a/im3d.cpp
+++ b/im3d.cpp
@@ -2335,10 +2335,17 @@ bool Context::gizmoAxisTranslation_Behavior(Id _id, const Vec3& _origin, const V
 		{
 			float tr, tl;
 			Nearest(ray, axisLine, tr, tl);
+			const Vec3 delta = _axis * tl - storedPosition;
 			#if IM3D_RELATIVE_SNAP
-				*_out_ = *_out_ + Snap(_axis * tl - storedPosition, _snap);
+				const float dist = Dot(delta, _axis);
+				const float snappedDist = Snap(dist, _snap);
+				*_out_ = *_out_ + _axis * snappedDist;
 			#else
-				*_out_ = Snap(*_out_ + _axis * tl - storedPosition, _snap);
+				const Vec3 absPos = *_out_ + delta;
+				const float absDist = Dot(absPos, _axis);
+				const float snappedAbs = Snap(absDist, _snap);
+				const Vec3 perp = *_out_ - _axis * Dot(*_out_, _axis);
+				*_out_ = perp + _axis * snappedAbs;
 			#endif
 
 			return true;


### PR DESCRIPTION
When using a translation gizmo with snapping and having a matrix pushed that has rotation, the gizmo shows the correct axes, but when actually translating along them, the object jumps in a weird "sawtooth" like pattern due to rounding down the X/Y/Z values of the vector regardless of how the axis is oriented:
```c++
inline static Vec3 Snap(const Vec3& _val, float _snap)
{
	if (_snap > 0.0f)
	{
		return Vec3(floorf(_val.x / _snap) * _snap, floorf(_val.y / _snap) * _snap, floorf(_val.z / _snap) * _snap);
	}
	return _val;
}
```

In this PR, this issue is fixed by projecting the travelled distance onto the axis and applying snap to that.